### PR TITLE
feat: add test mode to container

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ concept to make flexible injections.
 
 ## Require
 
-- Go >= 1.18
+- Go >= 1.20
 
 ## Install
 

--- a/container.go
+++ b/container.go
@@ -20,6 +20,7 @@ type Container interface {
 	Get(name types.Symbol) (any, error)
 	Flush()
 	Remove(name types.Symbol)
+	TestMode()
 }
 
 // get return a global instance for the dependency injection container. If the container is nil, then it will initialize
@@ -56,4 +57,10 @@ func Flush() {
 // this method on production, and just use it on testing purposes.
 func Remove[T symbolName](name T) {
 	get().Remove(types.Symbol(name))
+}
+
+// TestMode WARNING: Sets testMode flag to true, bypassing singleton instance generation to avoid race conditions when
+// container is used on test cases.
+func TestMode() {
+	get().TestMode()
 }

--- a/container_test.go
+++ b/container_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -257,4 +258,36 @@ func TestRemove(t *testing.T) {
 	_, err = Get[any](depName)
 
 	assert.Error(t, err)
+}
+
+func TestTestMode(t *testing.T) {
+	t.Run("get singleton instance on test mode", func(t *testing.T) {
+		TestMode()
+
+		type test struct {
+			number int
+		}
+
+		sym := types.Symbol("test")
+
+		err := Singleton(sym, func() test {
+			return test{number: rand.Int()}
+		})
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		obj1, errGet := Get[test](sym)
+		if errGet != nil {
+			t.Fatal(errGet)
+		}
+
+		obj2, errGet2 := Get[test](sym)
+		if errGet2 != nil {
+			t.Fatal(errGet2)
+		}
+
+		assert.NotEqual(t, obj1.number, obj2.number)
+	})
 }

--- a/get_test.go
+++ b/get_test.go
@@ -47,7 +47,7 @@ func TestGet(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Empty(t, ui)
-		assert.Equal(t, expErr, err)
+		assert.Equal(t, expErr.Error(), err.Error())
 	})
 
 	t.Run("cast type error", func(t *testing.T) {

--- a/injector/container.go
+++ b/injector/container.go
@@ -9,6 +9,7 @@ import (
 type Container struct {
 	solvedDeps map[types.Symbol]any
 	deps       map[types.Symbol]dependency.Dependency
+	testMode   bool
 }
 
 // New creates a new instance of a Container.
@@ -16,7 +17,14 @@ func New() *Container {
 	return &Container{
 		solvedDeps: make(map[types.Symbol]any),
 		deps:       make(map[types.Symbol]dependency.Dependency),
+		testMode:   false,
 	}
+}
+
+// TestMode WARNING: Sets testMode flag to true, bypassing singleton instance generation to avoid race conditions when
+// container is used on test cases.
+func (c *Container) TestMode() {
+	c.testMode = true
 }
 
 // Flush WARNING: This function will delete all saved instances, solved and registered factories from the container.

--- a/injector/container_test.go
+++ b/injector/container_test.go
@@ -9,6 +9,15 @@ import (
 	"github.com/Drafteame/container/types"
 )
 
+func TestContainer_EnableTestMode(t *testing.T) {
+	ic := New()
+	assert.False(t, ic.testMode)
+
+	ic.TestMode()
+
+	assert.True(t, ic.testMode)
+}
+
 func TestContainer_Flush(t *testing.T) {
 	depName := "test"
 

--- a/injector/get.go
+++ b/injector/get.go
@@ -16,7 +16,7 @@ func (c *Container) Get(name types.Symbol) (any, error) {
 		return nil, fmt.Errorf("inject: no provided dependency of name `%s`", name)
 	}
 
-	if dep.IsSingleton() {
+	if dep.IsSingleton() && !c.testMode {
 		return c.getSingleton(name, dep)
 	}
 
@@ -42,7 +42,7 @@ func (c *Container) getSingleton(name types.Symbol, dep dependency.Dependency) (
 func (c *Container) getInstance(dep dependency.Dependency) (any, error) {
 	val, err := dep.SetContainer(c).Build()
 	if err != nil {
-		return nil, fmt.Errorf("inject: error building dependency instance: %v", err)
+		return nil, fmt.Errorf("inject: error building dependency instance: %w", err)
 	}
 
 	return val, nil

--- a/injector/get_test.go
+++ b/injector/get_test.go
@@ -1,6 +1,8 @@
 package injector
 
 import (
+	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,30 +12,94 @@ import (
 )
 
 func TestContainer_Get(t *testing.T) {
-	c := New()
+	t.Run("get instance", func(t *testing.T) {
+		c := New()
 
-	type test struct {
-		name string
-	}
+		type test struct {
+			name string
+		}
 
-	sym := types.Symbol("test")
+		sym := types.Symbol("test")
 
-	err := c.Provide(sym, dependency.New(func() test {
-		return test{name: "test"}
-	}))
-	if err != nil {
-		t.Fatal(err)
-	}
+		err := c.Provide(sym, dependency.New(func() test {
+			return test{name: "test"}
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	obj, errGet := c.Get(sym)
-	if errGet != nil {
-		t.Fatal(errGet)
-	}
+		obj, errGet := c.Get(sym)
+		if errGet != nil {
+			t.Fatal(errGet)
+		}
 
-	tobj, ok := obj.(test)
-	if !ok {
-		t.Fatal("cant cast obj to test")
-	}
+		tobj, ok := obj.(test)
+		if !ok {
+			t.Fatal("cant cast obj to test")
+		}
 
-	assert.Equal(t, "test", tobj.name)
+		assert.Equal(t, "test", tobj.name)
+	})
+
+	t.Run("get singleton instance in regular mode", func(t *testing.T) {
+		c := New()
+
+		type test struct {
+			number int
+		}
+
+		sym := types.Symbol("test")
+
+		err := c.Provide(sym, dependency.NewSingleton(func() test {
+			return test{number: rand.Int()}
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		obj1, errGet := c.Get(sym)
+		if errGet != nil {
+			t.Fatal(errGet)
+		}
+
+		obj2, errGet2 := c.Get(sym)
+		if errGet2 != nil {
+			t.Fatal(errGet2)
+		}
+
+		fmt.Printf("obj1: %p\n", obj1)
+		fmt.Printf("obj2: %p\n", obj2)
+
+		assert.Equal(t, obj1.(test).number, obj2.(test).number)
+	})
+
+	t.Run("get singleton instance on test mode", func(t *testing.T) {
+		c := New()
+		c.TestMode()
+
+		type test struct {
+			number int
+		}
+
+		sym := types.Symbol("test")
+
+		err := c.Provide(sym, dependency.NewSingleton(func() test {
+			return test{number: rand.Int()}
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		obj1, errGet := c.Get(sym)
+		if errGet != nil {
+			t.Fatal(errGet)
+		}
+
+		obj2, errGet2 := c.Get(sym)
+		if errGet2 != nil {
+			t.Fatal(errGet2)
+		}
+
+		assert.NotEqual(t, obj1.(test).number, obj2.(test).number)
+	})
 }

--- a/injector/invoke_test.go
+++ b/injector/invoke_test.go
@@ -315,7 +315,7 @@ func TestContainer_Invoke(t *testing.T) {
 		expErr := fmt.Errorf("inject: error building dependency instance: inject: error constructing `func() (*injector.user, error)`: some")
 
 		assert.Error(t, err)
-		assert.Equal(t, expErr, err)
+		assert.Equal(t, expErr.Error(), err.Error())
 	})
 
 	t.Run("invoke with shared dependency on multiple targets as singleton", func(t *testing.T) {
@@ -397,7 +397,7 @@ func TestContainer_Invoke(t *testing.T) {
 		expErr := errors.New("inject: error building dependency instance: inject: error resolving argument 0 for constructor func(injector.database) *injector.user: inject: error building dependency instance: inject: error constructing `func(string) (*injector.driver, error)`: some")
 
 		assert.Error(t, err)
-		assert.Equal(t, expErr, err)
+		assert.Equal(t, expErr.Error(), err.Error())
 	})
 
 	t.Run("invoke with shared dependency that does not exist", func(t *testing.T) {
@@ -431,6 +431,6 @@ func TestContainer_Invoke(t *testing.T) {
 		expErr := errors.New("inject: error building dependency instance: inject: error resolving argument 0 for constructor func(injector.database) *injector.user: inject: no provided dependency of name `algo`")
 
 		assert.Error(t, err)
-		assert.Equal(t, expErr, err)
+		assert.Equal(t, expErr.Error(), err.Error())
 	})
 }


### PR DESCRIPTION
## Description

Container now has `TestMode` to avoid races on sigleton instances

## Task Context

### What is the current behavior?

When testing with container, singleton instances can't be replaced easily as we should replace the complete dependency three to avoid races.

### What is the new behavior?

With testing mode all dependency trees are thread as normal dependencies even if they were registered as singleton, this makes it easy to replace constructors as the containers do not save instances.

### Additional Context

```go
func TestFunction(t *testing.T) {
        container.TestMode()

        container.Singleton("some", func() int {
                return random.Int()
        })
        
        int1 := container.MustGet[int]("some")
        int2 := container.MustGet[int]("some")
        
        assert.NotEqual(t, int1, in2)
}
```

## Checklist

### How was it tested?

- [x] unit
- [ ] other (specify)

### Updated services

- [x] Does your code follow the project style guide?
- [x] Have you added tests that cover the changes and run them?
